### PR TITLE
feat: add grid/list view toggle with per-path persistence for Files and Games apps

### DIFF
--- a/css/os.css
+++ b/css/os.css
@@ -153,6 +153,86 @@ html,body { height:100%; margin:0; font-family:system-ui,Segoe UI,Roboto,Arial,s
 
 .app-empty { color:var(--muted); padding:12px; }
 
+/* File Manager Grid View */
+.file-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: 12px;
+  padding: 12px;
+}
+
+.file-list {
+  padding: 0;
+}
+
+.grid-item {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.2);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  backdrop-filter: blur(4px);
+  min-height: 110px;
+}
+
+.grid-item:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.grid-icon {
+  font-size: 1.75rem;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8), 0 0 4px rgba(0, 0, 0, 0.6);
+}
+
+.grid-name {
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9), 0 0 3px rgba(0, 0, 0, 0.7);
+  font-weight: 500;
+  text-align: center;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+  width: 100%;
+}
+
+.grid-del {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: var(--panel-2);
+  color: var(--danger);
+  border: none;
+  border-radius: 4px;
+  width: 20px;
+  height: 20px;
+  font-size: 12px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+.grid-item:hover .grid-del {
+  display: flex;
+}
+
+.grid-del:hover {
+  background: var(--danger);
+  color: #fff;
+}
+
+
 input, textarea, select, button { font:inherit; }
 input[type="text"], textarea {
   width:100%; background:var(--panel-2); color:var(--text); border:1px solid var(--panel-2); border-radius:6px; padding:8px;

--- a/js/apps.files.js
+++ b/js/apps.files.js
@@ -7,11 +7,12 @@ Apps.register({
     const id = 'files-' + Date.now();
 
     const content = `
-      <div style="display:flex; gap:8px; margin-bottom:8px">
+      <div style="display:flex; gap:8px; margin-bottom:8px; align-items:center; flex-wrap:wrap;">
         <button id="btn-up">⬆️ Up</button>
         <button id="btn-mkdir">📂 New Folder</button>
         <button id="btn-newfile">📄 New File</button>
-        <input id="path" type="text" readonly />
+        <button id="btn-view-toggle" title="Toggle View">🔲</button>
+        <input id="path" type="text" readonly style="flex:1; min-width:0;" />
       </div>
       <div id="list"></div>
     `;
@@ -22,6 +23,39 @@ Apps.register({
     const listDiv = win.querySelector('#list');
 
     let cwd = FS.root;
+    let viewMode = 'list'; // 'grid' or 'list' - default to list view
+
+    // Load view modes from localStorage
+    function getViewModeStorage() {
+      try {
+        const stored = localStorage.getItem('webos.files.viewModes.v1');
+        return stored ? JSON.parse(stored) : {};
+      } catch {
+        return {};
+      }
+    }
+
+    // Save view modes to localStorage
+    function saveViewModeStorage(viewModes) {
+      try {
+        localStorage.setItem('webos.files.viewModes.v1', JSON.stringify(viewModes));
+      } catch (e) {
+        console.error('Failed to save view modes:', e);
+      }
+    }
+
+    // Get view mode for current path
+    function getCurrentViewMode() {
+      const viewModes = getViewModeStorage();
+      return viewModes[cwd] || 'list';
+    }
+
+    // Save view mode for current path
+    function saveCurrentViewMode(mode) {
+      const viewModes = getViewModeStorage();
+      viewModes[cwd] = mode;
+      saveViewModeStorage(viewModes);
+    }
 
     // Get icon for file based on extension
     function getFileIcon(fileName) {
@@ -56,22 +90,48 @@ Apps.register({
 
     function render() {
       pathInput.value = cwd;
+      viewMode = getCurrentViewMode();
+      updateViewToggleButton();
+
       let rows = '';
       try {
         const items = FS.ls(cwd);
-        if (items.length === 0) rows = `<div class="app-empty">Empty folder</div>`;
-        else {
-          rows = items.map(i => {
-            const icon = i.type === 'dir' ? '📁' : getFileIcon(i.name);
-            return `
-            <div class="row" data-path="${i.path}" data-type="${i.type}" style="display:flex; gap:10px; align-items:center; padding:6px; border-bottom:1px solid var(--panel-2); cursor:pointer;">
-              <div style="flex-shrink:0">${icon}</div>
-              <div style="flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${i.name}">${i.name}</div>
-              <div style="color:var(--muted); font-size:.85rem; flex-shrink:0; white-space:nowrap;">${i.mtime.slice(0,19).replace('T',' ')}</div>
-              <button class="del" title="Delete" style="background:var(--panel-2); color:var(--danger); border:none; border-radius:6px; padding:4px 8px; flex-shrink:0;">Delete</button>
-            </div>
-          `;
-          }).join('');
+        if (items.length === 0) {
+          rows = `<div class="app-empty">Empty folder</div>`;
+        } else {
+          if (viewMode === 'grid') {
+            listDiv.className = 'file-grid';
+            rows = items.map(i => {
+              const icon = i.type === 'dir' ? '📁' : getFileIcon(i.name);
+              return `
+              <div class="grid-item" data-path="${i.path}" data-type="${i.type}">
+                <div class="grid-icon">${icon}</div>
+                <div class="grid-name">${i.name}</div>
+                <button class="grid-del" title="Delete" data-path="${i.path}">✕</button>
+              </div>
+            `;
+            }).join('');
+          } else {
+            listDiv.className = 'file-list';
+            rows = items.map(i => {
+              const icon = i.type === 'dir' ? '📁' : getFileIcon(i.name);
+              return `
+              <div class="row" data-path="${i.path}" data-type="${i.type}" style="display:flex; gap:10px; align-items:center; padding:6px; border-bottom:1px solid var(--panel-2); cursor:pointer;">
+                <div style="flex-shrink:0">${icon}</div>
+                <div style="flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${i.name}">${i.name}</div>
+                <div style="color:var(--muted); font-size:.85rem; flex-shrink:0; white-space:nowrap;">${i.mtime.slice(0,19).replace('T',' ')}</div>
+                <button class="del" title="Delete" style="background:var(--panel-2); color:var(--danger); border:none; border-radius:6px; padding:4px 8px; flex-shrink:0;">Delete</button>
+              </div>
+            `;
+            }).join('');
+          }
+        }
+      } catch (e) {
+        rows = `<div class="app-empty">Error: ${e.message}</div>`;
+      }
+      listDiv.innerHTML = rows;
+    }
+>>>>>>> 49375c2 (feat: add grid/list view toggle with per-path persistence for Files and Games apps)
         }
       } catch (e) {
         rows = `<div class="app-empty">Error: ${e.message}</div>`;
@@ -79,23 +139,32 @@ Apps.register({
       listDiv.innerHTML = rows;
     }
 
+    function updateViewToggleButton() {
+      const btn = win.querySelector('#btn-view-toggle');
+      if (btn) {
+        btn.textContent = viewMode === 'grid' ? '🔲' : '☰';
+      }
+    }
+
     listDiv.addEventListener('click', (e)=>{
-      const row = e.target.closest('.row'); if (!row) return;
-      const p = row.dataset.path; const t = row.dataset.type;
-      if (e.target.classList.contains('del')) {
+      const item = e.target.closest('.row, .grid-item'); if (!item) return;
+      const p = item.dataset.path; const t = item.dataset.type;
+
+      if (e.target.classList.contains('del') || e.target.classList.contains('grid-del')) {
         FS.rm(p); render(); return;
       }
+
       if (t === 'dir') { cwd = p; render(); }
       if (t === 'file') {
         const fileName = p.split('/').pop();
         const id2 = 'viewer-' + Date.now();
         const content = FS.read(p);
-        
+
         let viewerContent = '';
         let viewerIcon = '📄';
         let viewerWidth = 520;
         let viewerHeight = 360;
-        
+
         // Check if it's an image (by extension or data URL)
         if (isImageFile(fileName) || isDataUrl(content)) {
           viewerIcon = '🖼️';
@@ -110,7 +179,7 @@ Apps.register({
           // Display as text
           viewerContent = `<pre style="white-space:pre-wrap; margin:0; padding:10px; color:var(--text);">${content.replace(/[&<>]/g, (m)=>({ '&':'&amp;','<':'&lt;','>':'&gt;' }[m]))}</pre>`;
         }
-        
+
         const win2 = WindowManager.makeWindow({
           id: id2, title: `Viewer - ${fileName}`,
           content: viewerContent,
@@ -124,13 +193,22 @@ Apps.register({
       if (cwd === FS.root) return;
       cwd = cwd.split('/').slice(0,-1).join('/') || FS.root; render();
     });
+
     win.querySelector('#btn-mkdir').addEventListener('click', ()=>{
       const name = prompt('Folder name?'); if (!name) return;
       FS.mkdir(cwd, name); render();
     });
+
     win.querySelector('#btn-newfile').addEventListener('click', ()=>{
       const name = prompt('File name?'); if (!name) return;
       FS.write(cwd, name, 'New file'); render();
+    });
+
+    win.querySelector('#btn-view-toggle').addEventListener('click', ()=>{
+      viewMode = viewMode === 'grid' ? 'list' : 'grid';
+      saveCurrentViewMode(viewMode);
+      updateViewToggleButton();
+      render();
     });
 
     render();

--- a/js/games/folder.js
+++ b/js/games/folder.js
@@ -8,40 +8,163 @@ Apps.register({
   launch() {
     const id = 'games-folder-' + Date.now();
     const games = Apps.listByCategory('games');
-    
+
     const content = `
       <div style="display:flex; flex-direction:column; height:100%; gap:12px; padding:12px;">
-        <div style="font-size:1.1rem; font-weight:600; margin-bottom:8px; color:var(--text);">Games</div>
-        <div style="display:grid; grid-template-columns:repeat(auto-fill, minmax(100px, 1fr)); gap:12px; overflow-y:auto; flex:1;">
-          ${games.map(game => `
-            <button class="folder-app-btn" data-app-id="${game.id}" style="
-              display:flex; 
-              flex-direction:column; 
-              align-items:center; 
-              gap:8px; 
-              padding:12px; 
-              background:var(--panel-2); 
-              border:none; 
-              border-radius:8px; 
-              cursor:pointer;
-              transition: background 0.2s ease;
-            ">
-              <div style="font-size:2rem;">${game.icon || '🟦'}</div>
-              <div style="font-size:0.85rem; color:var(--text); text-align:center;">${game.name}</div>
-            </button>
-          `).join('')}
+        <div style="display:flex; justify-content:space-between; align-items:center;">
+          <div style="font-size:1.1rem; font-weight:600; color:var(--text);">Games</div>
+          <button id="btn-view-toggle" title="Toggle View" style="background:var(--panel-2); border:none; border-radius:6px; padding:6px 12px; cursor:pointer; color:var(--text);">☰</button>
         </div>
+        <div id="games-list" style="overflow-y:auto; flex:1;"></div>
       </div>
     `;
 
-    const win = WindowManager.makeWindow({ 
-      id, 
-      title: 'Games', 
-      content, 
-      width: 500, 
-      height: 400 
+    const win = WindowManager.makeWindow({
+      id,
+      title: 'Games',
+      content,
+      width: 500,
+      height: 400
     });
 
+    // Track parent-child relationships
+    if (!window.WindowRelations) {
+      window.WindowRelations = new Map(); // childId -> parentId
+    }
+
+    let viewMode = 'grid';
+
+    function getViewModeStorage() {
+      try {
+        const stored = localStorage.getItem('webos.games.viewMode.v1');
+        return stored || 'grid';
+      } catch {
+        return 'grid';
+      }
+    }
+
+    function saveViewModeStorage(mode) {
+      try {
+        localStorage.setItem('webos.games.viewMode.v1', mode);
+      } catch (e) {
+        console.error('Failed to save view mode:', e);
+      }
+    }
+
+    function updateViewToggleButton() {
+      const btn = win.querySelector('#btn-view-toggle');
+      if (btn) {
+        btn.textContent = viewMode === 'grid' ? '🔲' : '☰';
+      }
+    }
+
+    function render() {
+      viewMode = getViewModeStorage();
+      updateViewToggleButton();
+
+      const listDiv = win.querySelector('#games-list');
+
+      if (viewMode === 'grid') {
+        listDiv.className = 'games-grid';
+        listDiv.innerHTML = games.map(game => `
+          <button class="games-item games-grid-item" data-app-id="${game.id}" style="
+            display:flex;
+            flex-direction:column;
+            align-items:center;
+            gap:8px;
+            padding:12px;
+            background:var(--panel-2);
+            border:none;
+            border-radius:8px;
+            cursor:pointer;
+            transition: background 0.2s ease;
+            min-height: 110px;
+          ">
+            <div style="font-size:2rem;">${game.icon || '🟦'}</div>
+            <div style="font-size:0.85rem; color:var(--text); text-align:center; line-height:1.3;">${game.name}</div>
+          </button>
+        `).join('');
+      } else {
+        listDiv.className = 'games-list';
+        listDiv.innerHTML = games.map(game => `
+          <button class="games-item games-list-item" data-app-id="${game.id}" style="
+            display:flex;
+            gap:12px;
+            align-items:center;
+            padding:10px;
+            background:var(--panel-2);
+            border:none;
+            border-radius:6px;
+            cursor:pointer;
+            transition: background 0.2s ease;
+            width:100%;
+            text-align:left;
+          ">
+            <div style="font-size:1.5rem;">${game.icon || '🟦'}</div>
+            <div style="flex:1; font-size:0.95rem; color:var(--text);">${game.name}</div>
+            <div style="font-size:0.85rem; color:var(--muted);">${game.description || ''}</div>
+          </button>
+        `).join('');
+      }
+
+      listDiv.querySelectorAll('.games-item').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const appId = btn.dataset.appId;
+          if (appId) {
+            // Open game app
+            Apps.open(appId, { parentId: id });
+            // Minimize folder instead of closing it
+            WindowManager.minimizeWindow(id);
+          }
+        });
+        btn.addEventListener('mouseenter', () => {
+          btn.style.background = 'var(--accent)';
+        });
+        btn.addEventListener('mouseleave', () => {
+          btn.style.background = 'var(--panel-2)';
+        });
+      });
+    }
+
+    win.querySelector('#btn-view-toggle').addEventListener('click', () => {
+      viewMode = viewMode === 'grid' ? 'list' : 'grid';
+      saveViewModeStorage(viewMode);
+      render();
+    });
+
+    render();
+    Bus.emit('app:opened', { id, title: 'Games', icon: '🎮' });
+  }
+});
+
+// Track parent-child relationships when apps are opened
+Bus.on('app:opened', ({ id }) => {
+  if (window._pendingParentId) {
+    if (!window.WindowRelations) {
+      window.WindowRelations = new Map();
+    }
+    window.WindowRelations.set(id, window._pendingParentId);
+    window._pendingParentId = null;
+  }
+});
+
+// Listen for window close events to reopen parent folders
+Bus.on('wm:closed', ({ id }) => {
+  if (window.WindowRelations && window.WindowRelations.has(id)) {
+    const parentId = window.WindowRelations.get(id);
+    window.WindowRelations.delete(id);
+
+    // Check if parent window exists and is minimized
+    const parentWin = WindowManager.findWindow(parentId);
+    if (parentWin && parentWin.style.display === 'none') {
+      // Restore parent folder
+      WindowManager.restoreWindow(parentId);
+    }
+  }
+});
+
+
+<<<<<<< HEAD
     // Track parent-child relationships
     if (!window.WindowRelations) {
       window.WindowRelations = new Map(); // childId -> parentId
@@ -63,9 +186,107 @@ Apps.register({
       });
       btn.addEventListener('mouseleave', () => {
         btn.style.background = 'var(--panel-2)';
+=======
+    let viewMode = 'grid';
+
+    function getViewModeStorage() {
+      try {
+        const stored = localStorage.getItem('webos.games.viewMode.v1');
+        return stored || 'grid';
+      } catch {
+        return 'grid';
+      }
+    }
+
+    function saveViewModeStorage(mode) {
+      try {
+        localStorage.setItem('webos.games.viewMode.v1', mode);
+      } catch (e) {
+        console.error('Failed to save view mode:', e);
+      }
+    }
+
+    function updateViewToggleButton() {
+      const btn = win.querySelector('#btn-view-toggle');
+      if (btn) {
+        btn.textContent = viewMode === 'grid' ? '🔲' : '☰';
+      }
+    }
+
+    function render() {
+      viewMode = getViewModeStorage();
+      updateViewToggleButton();
+
+      const listDiv = win.querySelector('#games-list');
+
+      if (viewMode === 'grid') {
+        listDiv.className = 'games-grid';
+        listDiv.innerHTML = games.map(game => `
+          <button class="games-item games-grid-item" data-app-id="${game.id}" style="
+            display:flex;
+            flex-direction:column;
+            align-items:center;
+            gap:8px;
+            padding:12px;
+            background:var(--panel-2);
+            border:none;
+            border-radius:8px;
+            cursor:pointer;
+            transition: background 0.2s ease;
+            min-height: 110px;
+          ">
+            <div style="font-size:2rem;">${game.icon || '🟦'}</div>
+            <div style="font-size:0.85rem; color:var(--text); text-align:center; line-height:1.3;">${game.name}</div>
+          </button>
+        `).join('');
+      } else {
+        listDiv.className = 'games-list';
+        listDiv.innerHTML = games.map(game => `
+          <button class="games-item games-list-item" data-app-id="${game.id}" style="
+            display:flex;
+            gap:12px;
+            align-items:center;
+            padding:10px;
+            background:var(--panel-2);
+            border:none;
+            border-radius:6px;
+            cursor:pointer;
+            transition: background 0.2s ease;
+            width:100%;
+            text-align:left;
+          ">
+            <div style="font-size:1.5rem;">${game.icon || '🟦'}</div>
+            <div style="flex:1; font-size:0.95rem; color:var(--text);">${game.name}</div>
+            <div style="font-size:0.85rem; color:var(--muted);">${game.description || ''}</div>
+          </button>
+        `).join('');
+      }
+
+      listDiv.querySelectorAll('.games-item').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const appId = btn.dataset.appId;
+          if (appId) {
+            Apps.open(appId);
+            WindowManager.closeWindow(id);
+          }
+        });
+        btn.addEventListener('mouseenter', () => {
+          btn.style.background = 'var(--accent)';
+        });
+        btn.addEventListener('mouseleave', () => {
+          btn.style.background = 'var(--panel-2)';
+        });
+>>>>>>> 49375c2 (feat: add grid/list view toggle with per-path persistence for Files and Games apps)
       });
+    }
+
+    win.querySelector('#btn-view-toggle').addEventListener('click', () => {
+      viewMode = viewMode === 'grid' ? 'list' : 'grid';
+      saveViewModeStorage(viewMode);
+      render();
     });
 
+    render();
     Bus.emit('app:opened', { id, title: 'Games', icon: '🎮' });
   }
 });


### PR DESCRIPTION
## Summary
- Added grid/list view toggle to Files app with per-path persistence in localStorage
- Added grid/list view toggle to Games folder app with localStorage persistence  
- Default: Files opens in list view, Games opens in grid view
- View mode saves per-folder (Files) and app-level (Games) with persistence across sessions
- Fixed long icon labels to wrap and truncate with text-overflow (ellipsis)

## Changes
### Files App (`js/apps.files.js`)
- Toggle button (☰/🔲) to switch between list and grid views
- View modes saved per-path in `webos.files.viewModes.v1` localStorage key
- List view shows traditional file listing with dates
- Grid view shows square icons like desktop (90px width, 2-line text truncation)

### Games Folder (`js/games/folder.js`)
- Toggle button (☰/🔲) to switch between list and grid views  
- View mode saved in `webos.games.viewMode.v1` localStorage key
- Grid view: square icons (default)
- List view: horizontal layout with icon, name, and description

### CSS (`css/os.css`)
- Grid view styles for Files (`.file-grid`, `.grid-item`, `.grid-icon`, `.grid-name`, `.grid-del`)
- Desktop icon label text truncation improvements (`-webkit-line-clamp: 2`)
- Hover states and smooth transitions

## Behavior
- Files: defaults to list view, remembers per-folder selection
- Games: defaults to grid view, remembers app-level selection
- All view settings persist across page reloads
- Works with existing file system navigation