### PR TITLE
fix: reset new game button icon on restart

### DIFF
--- a/js/games/minesweeper.js
+++ b/js/games/minesweeper.js
@@ -74,6 +74,11 @@ Apps.register({
         timer = null;
       }
 
+      const statusEl = win.querySelector('#minesweeper-status');
+      if (statusEl) {
+        statusEl.textContent = '😊';
+      }
+
       renderGrid();
       updateUI();
     }


### PR DESCRIPTION
## Summary

Fixed bug where the new game button status emoji was not being reset when restarting the game.

## Changes

- Added icon reset in `initGame()` to set status emoji back to 😊
- This affects both manual restarts via clicking the status button and automatic restarts when changing difficulty

## Technical Details

The status emoji shows 😊 (playing), 😵 (game over), or 😎 (win). When restarting the game, the icon was remaining in its previous state instead of resetting to 😊. This is now fixed.

Part of #25